### PR TITLE
Trigger callback when no migrations need to be run

### DIFF
--- a/lib/models/migration.js
+++ b/lib/models/migration.js
@@ -195,6 +195,7 @@ module.exports = function(Migration, options) {
         delete Migration.app.migrating;
         Migration.emit('complete');
         Migration.log.info('No new migrations to run.');
+        return cb();
       }
     });
 


### PR DESCRIPTION
Previously, when no migration were run the Migration model would keep hanging, without calling the callback or returning the Promise. This PR fixes that.